### PR TITLE
Fix for memory leak in external tables.

### DIFF
--- a/external-table/src/gpdbwritableformatter.c
+++ b/external-table/src/gpdbwritableformatter.c
@@ -688,6 +688,8 @@ gpdbwritableformatter_export(PG_FUNCTION_ARGS)
 	nullBit = boolArrayToByteArray(myData->nulls, ncolumns, nvalidcolumns, &nullBitLen, tupdesc);
 	appendBinaryStringInfo(myData->export_format_tuple, (char *) nullBit, nullBitLen);
 
+	pfree(nullBit);
+
 	/* Column Value */
 	for (i = 0; i < ncolumns; i++)
 	{


### PR DESCRIPTION
The function `boolArrayToByteArray` called from `src/gpdbwritableformatter.c` 
allocates memory and returns a pointer, this memory is allocated for each tuple, 
but returned only at context free. This leads to enormous memory consumption 
when processing larger datasets.

This patch add memory deallocation for the result of the boolArrayToByteArray.