### PR TITLE
CI-5526: Implement CODEOWNERS approach for GitHub workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/.github/ @GreengageDB/ci


### PR DESCRIPTION
## Implement CODEOWNERS approach for GitHub workflows (#33)

- add CODEOWNERS to protect .github directory

  Assign @GreengageDB/ci as the required reviewer for all files
  under the .github/ directory, including workflows, actions,
  and other CI configuration.
  
  This ensures that no changes to CI pipelines or GitHub
  configuration can be merged without explicit approval from
  the CI team, preventing accidental or unauthorized
  modifications to workflow files (e.g. developer container
  tags left in greengage-ci.yml after local testing).
  
  Requires branch protection rule "Require review from Code Owners"
  to be enabled on the target branch to enforce this policy.

Task: [CI-5526](https://tracker.yandex.ru/CI-5526)