### PR TITLE
ENGINEER-5662: Add supporting jdbc timestamp with time zone postgresq…

### DIFF
--- a/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcResolver.java
+++ b/server/pxf-jdbc/src/main/java/org/greenplum/pxf/plugins/jdbc/JdbcResolver.java
@@ -45,6 +45,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 import static org.greenplum.pxf.api.GreenplumDateTime.DATETIME_FORMATTER;
 import static org.greenplum.pxf.api.GreenplumDateTime.DATE_FORMATTER;
@@ -71,6 +72,7 @@ public class JdbcResolver extends JdbcBasePlugin implements Resolver {
             DataType.SMALLINT,
             DataType.NUMERIC,
             DataType.TIMESTAMP,
+            DataType.TIMESTAMP_WITH_TIME_ZONE,
             DataType.DATE,
             DataType.JSON,
             DataType.JSONB
@@ -91,6 +93,46 @@ public class JdbcResolver extends JdbcBasePlugin implements Resolver {
      */
     JdbcResolver(ConnectionManager connectionManager, SecureLogin secureLogin, DecryptClient decryptClient) {
         super(connectionManager, secureLogin, decryptClient);
+    }
+
+    /**
+     * Pre-compiled patterns for timestamptz normalization.
+     * Used to avoid recompiling regex on every method call.
+     */
+    private static final Pattern TZ_OFFSET_HH = Pattern.compile("([+-])(\\d{2})$");
+    private static final Pattern TZ_OFFSET_HHMM = Pattern.compile("([+-])(\\d{2})(\\d{2})$");
+
+    /**
+     * Minimal normalization of PostgreSQL timestamptz string for OffsetDateTime.parse().
+     * - Replaces space with 'T' between date and time
+     * - Adds :00 to timezone offset if missing (e.g., +03 → +03:00)
+     * - For strings with era markers (BC/AD), parsing is delegated to OFFSET_DATE_TIME_FORMATTER
+     *
+     * @param pgTimestamp the timestamp string from PostgreSQL
+     * @return normalized ISO 8601 compatible string, or null if input is null
+     */
+    private static String normalizePostgresTimestamp(String pgTimestamp) {
+        if (pgTimestamp == null) return null;
+
+        var result = pgTimestamp.trim();
+
+        // Replace first space (date/time separator) with 'T' for ISO 8601
+        int spaceIdx = result.indexOf(' ');
+        if (spaceIdx > 0) {
+            result = result.substring(0, spaceIdx) + 'T' + result.substring(spaceIdx + 1);
+        }
+
+        // Normalize timezone offset at the end of the string using pre-compiled patterns
+        // +HH or -HH → +HH:00 or -HH:00
+        if (TZ_OFFSET_HH.matcher(result).find()) {
+            result = TZ_OFFSET_HH.matcher(result).replaceAll("$1$2:00");
+        }
+        // +HHMM or -HHMM → +HH:MM or -HH:MM (rare, but handled for robustness)
+        else if (TZ_OFFSET_HHMM.matcher(result).find()) {
+            result = TZ_OFFSET_HHMM.matcher(result).replaceAll("$1$2:$3");
+        }
+
+        return result;
     }
 
     /**
@@ -262,6 +304,20 @@ public class JdbcResolver extends JdbcBasePlugin implements Resolver {
                             oneField.val = Timestamp.valueOf(rawVal);
                         }
                         break;
+                    case TIMESTAMP_WITH_TIME_ZONE:
+                        if (isDateWideRange) {
+                            if (rawVal.contains(" BC") || rawVal.contains(" AD")) {
+                                oneField.val = OFFSET_DATE_TIME_FORMATTER.parse(rawVal, OffsetDateTime::from);
+                            } else {
+                                String normalized = normalizePostgresTimestamp(rawVal);
+                                oneField.val = OffsetDateTime.parse(normalized);
+                            }
+                        } else {
+                            throw new UnsupportedOperationException(
+                                    String.format("Column type '%s' (column '%s') is not supported. Try to use the property DATE_WIDE_RANGE=true",
+                                            columnType, column));
+                        }
+                        break;
                     case DATE:
                         if (isDateWideRange) {
                             oneField.val = getLocalDate(rawVal);
@@ -371,6 +427,21 @@ public class JdbcResolver extends JdbcBasePlugin implements Resolver {
                             statement.setObject(i, field.val);
                         } else {
                             statement.setTimestamp(i, (Timestamp) field.val);
+                        }
+                    }
+                    break;
+                case TIMESTAMP_WITH_TIME_ZONE:
+                    if (field.val == null) {
+                        statement.setNull(i, Types.TIMESTAMP_WITH_TIMEZONE);
+                    } else {
+                        if (field.val instanceof OffsetDateTime) {
+                            statement.setObject(i, field.val);
+                        } else if (field.val instanceof String) {
+                            String normalized = normalizePostgresTimestamp((String) field.val);
+                            OffsetDateTime odt = OffsetDateTime.parse(normalized);
+                            statement.setObject(i, odt);
+                        } else {
+                            throw new IOException("Unexpected value type for TIMESTAMP_WITH_TIME_ZONE: " + field.val.getClass());
                         }
                     }
                     break;

--- a/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcResolverTest.java
+++ b/server/pxf-jdbc/src/test/java/org/greenplum/pxf/plugins/jdbc/JdbcResolverTest.java
@@ -21,6 +21,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.sql.Types;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
@@ -427,6 +428,188 @@ class JdbcResolverTest {
         JdbcResolver.decodeOneRowToPreparedStatement(row, mockStatement, mock(DbProduct.class));
 
         verify(mockStatement).setObject(1, UUID.fromString("decafbad-0000-0000-0000-000000000000"));
+        verifyNoMoreInteractions(mockStatement);
+    }
+
+    @Test
+    void setFieldOffsetDateTimeWithWideRangeTest() {
+        isDateWideRange = true;
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        OffsetDateTime expected = OffsetDateTime.parse("1977-12-11T10:15:30.1234+05:00");
+        // PostgreSQL format: space separator, timezone with minutes
+        String timestampTz = "1977-12-11 10:15:30.1234+05:00";
+        OneField oneField = setFields(timestampTz, DataType.TIMESTAMP_WITH_TIME_ZONE.getOID(), "timestamptz");
+        assertTrue(oneField.val instanceof OffsetDateTime);
+        assertEquals(expected, oneField.val);
+    }
+
+    @Test
+    void setFieldOffsetDateTimeWithoutWideRangeTest() {
+        isDateWideRange = false;
+        String timestampTz = "1977-12-11 10:15:30.1234+05:00";
+        assertThrows(UnsupportedOperationException.class,
+                () -> setFields(timestampTz, DataType.TIMESTAMP_WITH_TIME_ZONE.getOID(), "timestamptz"));
+    }
+
+    @Test
+    void setFieldOffsetDateTimeWithWideRange_TimezoneWithoutMinutesTest() {
+        isDateWideRange = true;
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        OffsetDateTime expected = OffsetDateTime.parse("2026-05-20T13:10:08.50411+03:00");
+        // PostgreSQL format: timezone without minutes (+03 instead of +03:00)
+        String timestampTz = "2026-05-20 13:10:08.50411+03";
+        OneField oneField = setFields(timestampTz, DataType.TIMESTAMP_WITH_TIME_ZONE.getOID(), "timestamptz");
+        assertTrue(oneField.val instanceof OffsetDateTime);
+        assertEquals(expected, oneField.val);
+    }
+
+    @Test
+    void setFieldOffsetDateTimeWithWideRange_NegativeTimezoneTest() {
+        isDateWideRange = true;
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        OffsetDateTime expected = OffsetDateTime.parse("2026-05-20T13:10:08.50411-08:00");
+        String timestampTz = "2026-05-20 13:10:08.50411-08";
+        OneField oneField = setFields(timestampTz, DataType.TIMESTAMP_WITH_TIME_ZONE.getOID(), "timestamptz");
+        assertTrue(oneField.val instanceof OffsetDateTime);
+        assertEquals(expected, oneField.val);
+    }
+
+    @Test
+    void setFieldOffsetDateTimeWithWideRange_WithLeadingZeroTest() {
+        isDateWideRange = true;
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        OffsetDateTime expected = OffsetDateTime.parse("0003-01-02T04:05:06.0000015+03:00");
+        String timestampTz = "0003-01-02 04:05:06.0000015+03:00 AD";
+        OneField oneField = setFields(timestampTz, DataType.TIMESTAMP_WITH_TIME_ZONE.getOID(), "timestamptz");
+        assertTrue(oneField.val instanceof OffsetDateTime);
+        assertEquals(expected, oneField.val);
+    }
+
+    @Test
+    void setFieldOffsetDateTimeWithWideRange_WithMoreThan4DigitsInYearTest() {
+        isDateWideRange = true;
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        OffsetDateTime expected = OffsetDateTime.parse("+9876543-12-11T11:15:30.1234-03:00");
+        String timestampTz = "9876543-12-11 11:15:30.1234-03:00 AD";
+        OneField oneField = setFields(timestampTz, DataType.TIMESTAMP_WITH_TIME_ZONE.getOID(), "timestamptz");
+        assertTrue(oneField.val instanceof OffsetDateTime);
+        assertEquals(expected, oneField.val);
+    }
+
+    @Test
+    void setFieldOffsetDateTimeWithWideRange_WithEraBCTest() {
+        isDateWideRange = true;
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        OffsetDateTime expected = OffsetDateTime.parse("-3456-12-11T11:15:30+02:00");
+        String timestampTz = "3457-12-11 11:15:30+02:00 BC";
+        OneField oneField = setFields(timestampTz, DataType.TIMESTAMP_WITH_TIME_ZONE.getOID(), "timestamptz");
+        assertTrue(oneField.val instanceof OffsetDateTime);
+        assertEquals(expected, oneField.val);
+    }
+
+    @Test
+    void setFieldOffsetDateTimeWithWideRange_WithEraADTest() {
+        isDateWideRange = true;
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        OffsetDateTime expected = OffsetDateTime.parse("1234-06-15T08:30:45+01:00");
+        String timestampTz = "1234-06-15 08:30:45+01:00 AD";
+        OneField oneField = setFields(timestampTz, DataType.TIMESTAMP_WITH_TIME_ZONE.getOID(), "timestamptz");
+        assertTrue(oneField.val instanceof OffsetDateTime);
+        assertEquals(expected, oneField.val);
+    }
+
+    @Test
+    void setFieldOffsetDateTimeWithWideRange_WithEraWithoutWideRangeTest() {
+        isDateWideRange = false;
+        String timestampTz = "3457-12-11 11:15:30+02:00 BC";
+        assertThrows(UnsupportedOperationException.class,
+                () -> setFields(timestampTz, DataType.TIMESTAMP_WITH_TIME_ZONE.getOID(), "timestamptz"));
+    }
+
+    @Test
+    void setFieldOffsetDateTimeWithWideRange_NullValueTest() {
+        isDateWideRange = true;
+        oneFieldList.add(new OneField(DataType.TEXT.getOID(), null));
+        columnDescriptors.add(new ColumnDescriptor("tstz_col", DataType.TIMESTAMP_WITH_TIME_ZONE.getOID(), 0, "timestamptz", null));
+        context.setTupleDescription(columnDescriptors);
+        resolver.columns = context.getTupleDescription();
+        resolver.isDateWideRange = isDateWideRange;
+
+        OneRow oneRow = resolver.setFields(oneFieldList);
+        @SuppressWarnings("unchecked")
+        List<OneField> oneFields = (List<OneField>) oneRow.getData();
+        assertNull(oneFields.get(0).val);
+    }
+
+    @Test
+    void setFieldOffsetDateTimeWithWideRange_ZoneWithMinutesAlreadyTest() {
+        isDateWideRange = true;
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        OffsetDateTime expected = OffsetDateTime.parse("2026-05-20T13:10:08.50411+05:30");
+        // Timezone already has minutes — should not be modified
+        String timestampTz = "2026-05-20 13:10:08.50411+05:30";
+        OneField oneField = setFields(timestampTz, DataType.TIMESTAMP_WITH_TIME_ZONE.getOID(), "timestamptz");
+        assertTrue(oneField.val instanceof OffsetDateTime);
+        assertEquals(expected, oneField.val);
+    }
+
+    @Test
+    void setFieldOffsetDateTimeWithWideRange_ZoneWithFourDigitsTest() {
+        isDateWideRange = true;
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        OffsetDateTime expected = OffsetDateTime.parse("2026-05-20T13:10:08.50411+05:30");
+        String timestampTz = "2026-05-20 13:10:08.50411+0530";
+        OneField oneField = setFields(timestampTz, DataType.TIMESTAMP_WITH_TIME_ZONE.getOID(), "timestamptz");
+        assertTrue(oneField.val instanceof OffsetDateTime);
+        assertEquals(expected, oneField.val);
+    }
+
+    @Test
+    void setFieldOffsetDateTimeWithWideRange_ZoneZTest() {
+        isDateWideRange = true;
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        OffsetDateTime expected = OffsetDateTime.parse("2026-05-20T13:10:08.50411Z");
+        // UTC timezone as 'Z' — should not be modified
+        String timestampTz = "2026-05-20 13:10:08.50411Z";
+        OneField oneField = setFields(timestampTz, DataType.TIMESTAMP_WITH_TIME_ZONE.getOID(), "timestamptz");
+        assertTrue(oneField.val instanceof OffsetDateTime);
+        assertEquals(expected, oneField.val);
+    }
+
+    @Test
+    void decodeOneRowToPreparedStatement_TimestampWithTimeZone_OffsetDateTimeTest() throws SQLException, IOException {
+        OffsetDateTime odt = OffsetDateTime.parse("2026-05-20T13:10:08.50411+03:00");
+        oneFieldList.add(new OneField(DataType.TIMESTAMP_WITH_TIME_ZONE.getOID(), odt));
+        when(row.getData()).thenReturn(oneFieldList);
+
+        JdbcResolver.decodeOneRowToPreparedStatement(row, mockStatement, DbProduct.POSTGRES);
+
+        verify(mockStatement).setObject(1, odt);
+        verifyNoMoreInteractions(mockStatement);
+    }
+
+    @Test
+    void decodeOneRowToPreparedStatement_TimestampWithTimeZone_StringTest() throws SQLException, IOException {
+        // String value from Greenplum needs normalization before parsing
+        String timestampTz = "2026-05-20 13:10:08.50411+03";
+        oneFieldList.add(new OneField(DataType.TIMESTAMP_WITH_TIME_ZONE.getOID(), timestampTz));
+        when(row.getData()).thenReturn(oneFieldList);
+
+        JdbcResolver.decodeOneRowToPreparedStatement(row, mockStatement, DbProduct.POSTGRES);
+
+        OffsetDateTime expected = OffsetDateTime.parse("2026-05-20T13:10:08.50411+03:00");
+        verify(mockStatement).setObject(1, expected);
+        verifyNoMoreInteractions(mockStatement);
+    }
+
+    @Test
+    void decodeOneRowToPreparedStatement_TimestampWithTimeZone_NullTest() throws SQLException, IOException {
+        oneFieldList.add(new OneField(DataType.TIMESTAMP_WITH_TIME_ZONE.getOID(), null));
+        when(row.getData()).thenReturn(oneFieldList);
+
+        JdbcResolver.decodeOneRowToPreparedStatement(row, mockStatement, DbProduct.POSTGRES);
+
+        verify(mockStatement).setNull(1, Types.TIMESTAMP_WITH_TIMEZONE);
         verifyNoMoreInteractions(mockStatement);
     }
 


### PR DESCRIPTION
### Root Cause
PostgreSQL returns `timestamptz` values in format:
- `yyyy-MM-dd HH:mm:ss[.ffffff][+HH]` (space separator, timezone without minutes)

But `OffsetDateTime.parse()` expects ISO 8601 format:
- `yyyy-MM-ddTHH:mm:ss[.ffffff][+HH:MM]` ('T' separator, timezone with minutes)

### Solution
1. Added `TIMESTAMP_WITH_TIME_ZONE` to `DATATYPES_SUPPORTED` set
2. Added handling for `TIMESTAMP_WITH_TIME_ZONE` in `setFields()` method:
   - For values with era markers (BC/AD): delegate to existing `OFFSET_DATE_TIME_FORMATTER`
   - For regular values: normalize format and parse with `OffsetDateTime.parse()`
3. Added handling for `TIMESTAMP_WITH_TIME_ZONE` in `decodeOneRowToPreparedStatement()`:
   - Normalize string values before parsing to `OffsetDateTime`
4. Added minimal `normalizePostgresTimestamp()` helper method that:
   - Replaces space with 'T' between date and time
   - Adds `:00` to timezone offset if missing (e.g., `+03` → `+03:00`)