### PR TITLE
[Draft] ADBDEV-9857: Implement dynamic load of functions and calls via virtual table

### DIFF
--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -18,7 +18,7 @@ env:
     [
       { "version": "6", "image": "greengagedb/ggdb", "tag": "6.30.1"  },
       { "version": "7", "image": "greengagedb/ggdb", "tag": "7.4.0"   },
-      { "version": "6", "image": "ghcr.io/greengagedb/greengage/ggdb", "tag": "latest" },
+      { "version": "6", "image": "ghcr.io/greengagedb/greengage/ggdb", "tag": "ADBDEV-9854" },
       { "version": "7", "image": "ghcr.io/greengagedb/greengage/ggdb", "tag": "latest" }
     ]
   TESTS: |

--- a/.github/workflows/greengage-ci.yml
+++ b/.github/workflows/greengage-ci.yml
@@ -16,10 +16,7 @@ concurrency:
 env:
   IMAGES: |
     [
-      { "version": "6", "image": "greengagedb/ggdb", "tag": "6.30.1"  },
-      { "version": "7", "image": "greengagedb/ggdb", "tag": "7.4.0"   },
-      { "version": "6", "image": "ghcr.io/greengagedb/greengage/ggdb", "tag": "ADBDEV-9854" },
-      { "version": "7", "image": "ghcr.io/greengagedb/greengage/ggdb", "tag": "latest" }
+      { "version": "6", "image": "ghcr.io/greengagedb/greengage/ggdb", "tag": "ADBDEV-9854" }
     ]
   TESTS: |
     [

--- a/ci/test_in_docker.sh
+++ b/ci/test_in_docker.sh
@@ -23,7 +23,7 @@ sed -i \
 chown gpadmin:gpadmin -R $PXF_SRC
 
 # Display the diff if we fail
-trap "cat $PXF_SRC/fdw/regression.diffs $PXF_SRC/external-table/regression.diffs" ERR
+trap "find $PXF_SRC -type f -name '*.diffs' -exec cat {} \;" ERR
 
 # test fdw and external-table
 echo "=============================="

--- a/fdw/Makefile
+++ b/fdw/Makefile
@@ -7,7 +7,7 @@ with_llvm = no
 
 is_ssl_supported :=$(filter https,$(PXF_PROTOCOL))
 REGRESS_COMMON = pxf_fdw_wrapper pxf_fdw_server pxf_fdw_user_mapping pxf_fdw_foreign_table
-REGRESS_HTTP   = pxf_fdw_http
+# REGRESS_HTTP   = pxf_fdw_http
 REGRESS_HTTPS  := $(if $(is_ssl_supported), pxf_fdw_ssl)
 REGRESS        = $(REGRESS_COMMON) $(REGRESS_HTTP) $(REGRESS_HTTPS)
 SHLIB_LINK += -lcurl
@@ -46,3 +46,11 @@ installcheck-http:
 .PHONY: installcheck-https
 installcheck-https:
 	$(MAKE) installcheck REGRESS="$(REGRESS_COMMON) $(REGRESS_HTTPS)"
+
+installcheck: isolationcheck
+
+ISOLATION2_ROOT=$(pgxsdir)/src/test/isolation2
+
+isolationcheck: submake
+	make ISOLATION2_ROOT=$(ISOLATION2_ROOT) -C isolation2 isolationcheck
+

--- a/fdw/Makefile
+++ b/fdw/Makefile
@@ -7,7 +7,7 @@ with_llvm = no
 
 is_ssl_supported :=$(filter https,$(PXF_PROTOCOL))
 REGRESS_COMMON = pxf_fdw_wrapper pxf_fdw_server pxf_fdw_user_mapping pxf_fdw_foreign_table
-# REGRESS_HTTP   = pxf_fdw_http
+REGRESS_HTTP   = pxf_fdw_http
 REGRESS_HTTPS  := $(if $(is_ssl_supported), pxf_fdw_ssl)
 REGRESS        = $(REGRESS_COMMON) $(REGRESS_HTTP) $(REGRESS_HTTPS)
 SHLIB_LINK += -lcurl

--- a/fdw/isolation2/Makefile
+++ b/fdw/isolation2/Makefile
@@ -1,0 +1,10 @@
+ISOLATIONCHECKS = pxf_fdw_metadata
+
+isolationcheck:
+ifndef ISOLATION2_ROOT
+	$(error ISOLATION2_ROOT is undefined)
+endif
+	$(ISOLATION2_ROOT)/pg_isolation2_regress $(EXTRA_REGRESS_OPTS) \
+		--inputdir=${CURDIR} \
+		--outputdir=${CURDIR} \
+		$(ISOLATIONCHECKS)

--- a/fdw/isolation2/expected/pxf_fdw_metadata.out
+++ b/fdw/isolation2/expected/pxf_fdw_metadata.out
@@ -1,7 +1,7 @@
 CREATE EXTENSION IF NOT EXISTS pxf_fdw;
 CREATE
 
-2:!& python3 pxf_mock.py > /tmp/pxf_mock.log 2>&1; 
+2:!& python3 pxf_mock.py > /tmp/pxf_mock.log 2>&1;
 select pg_sleep(1);
  pg_sleep 
 ----------
@@ -48,7 +48,7 @@ SELECT * FROM test_t ORDER BY t0;
  t0 | 1  
 (3 rows)
 
-1:!& curl http://localhost:5889/shutdown; 
+1:!& curl http://localhost:5889/shutdown;
 2<:  <... completed>
 FAILED:  Execution failed
 

--- a/fdw/isolation2/expected/pxf_fdw_metadata.out
+++ b/fdw/isolation2/expected/pxf_fdw_metadata.out
@@ -1,0 +1,132 @@
+CREATE EXTENSION IF NOT EXISTS pxf_fdw;
+CREATE
+
+2:!& python3 pxf_mock.py > /tmp/pxf_mock.log 2>&1; 
+select pg_sleep(1);
+ pg_sleep 
+----------
+          
+(1 row)
+
+CREATE FOREIGN DATA WRAPPER pxf_ext_v1 HANDLER pxf_fdw_handler VALIDATOR pxf_fdw_validator OPTIONS (protocol 'system', mpp_execute 'all segments', pxf_protocol 'http', pxf_port '5889', ext_protocol_version 'v1' );
+CREATE
+
+CREATE SERVER pxf_ext_v1_server FOREIGN DATA WRAPPER pxf_ext_v1;
+CREATE
+
+CREATE USER MAPPING FOR CURRENT_USER SERVER pxf_ext_v1_server;
+CREATE
+
+CREATE FOREIGN TABLE test_t( t0 text, a1 integer ) SERVER pxf_ext_v1_server OPTIONS (resource 'fdw_file', format 'csv', delimiter ',');
+CREATE
+
+-- ANALYZE is not supported by pxf_fdw
+set gp_autostats_mode = none;
+SET
+set client_min_messages = info;
+SET
+
+INSERT INTO test_t VALUES('hello world', 1);
+INSERT 1
+
+SELECT * FROM test_t ORDER BY t0;
+ t0 | a1 
+----+----
+ t0 | 1  
+ t0 | 1  
+ t0 | 1  
+(3 rows)
+
+INSERT INTO test_t VALUES('hello world', 1);
+INSERT 1
+
+SELECT * FROM test_t ORDER BY t0;
+ t0 | a1 
+----+----
+ t0 | 1  
+ t0 | 1  
+ t0 | 1  
+(3 rows)
+
+1:!& curl http://localhost:5889/shutdown; 
+2<:  <... completed>
+FAILED:  Execution failed
+
+-- sleep to allow the shell properly close the files
+1: select pg_sleep(1);
+ pg_sleep 
+----------
+          
+(1 row)
+
+1:! cat /tmp/pxf_mock.log;
+Starting mock PXF server on port 5889...
+"POST /pxf/v1/write HTTP/1.1" 200 -
+"POST /pxf/v1/write HTTP/1.1" 200 -
+"POST /pxf/v1/write HTTP/1.1" 200 -
+
+--- Incoming Request ---
+Method: POST
+Path: /pxf/v1/commit
+Query Params: {}
+<MetadataItem: b'Some test metadata for 0' (24)>
+<MetadataItem: b'Some test metadata for 1' (24)>
+<MetadataItem: b'Some test metadata for 2' (24)>
+"POST /pxf/v1/commit HTTP/1.1" 200 -
+
+--- Incoming Request ---
+Method: GET
+Path: /pxf/read
+Query Params: {}
+"GET /pxf/read HTTP/1.1" 200 -
+
+--- Incoming Request ---
+Method: GET
+Path: /pxf/read
+Query Params: {}
+"GET /pxf/read HTTP/1.1" 200 -
+
+--- Incoming Request ---
+Method: GET
+Path: /pxf/read
+Query Params: {}
+"GET /pxf/read HTTP/1.1" 200 -
+"POST /pxf/v1/write HTTP/1.1" 200 -
+"POST /pxf/v1/write HTTP/1.1" 200 -
+"POST /pxf/v1/write HTTP/1.1" 200 -
+
+--- Incoming Request ---
+Method: POST
+Path: /pxf/v1/commit
+Query Params: {}
+<MetadataItem: b'Some test metadata for 0' (24)>
+<MetadataItem: b'Some test metadata for 1' (24)>
+<MetadataItem: b'Some test metadata for 2' (24)>
+"POST /pxf/v1/commit HTTP/1.1" 200 -
+
+--- Incoming Request ---
+Method: GET
+Path: /pxf/read
+Query Params: {}
+"GET /pxf/read HTTP/1.1" 200 -
+
+--- Incoming Request ---
+Method: GET
+Path: /pxf/read
+Query Params: {}
+"GET /pxf/read HTTP/1.1" 200 -
+
+--- Incoming Request ---
+Method: GET
+Path: /pxf/read
+Query Params: {}
+"GET /pxf/read HTTP/1.1" 200 -
+
+--- Incoming Request ---
+Method: GET
+Path: /shutdown
+Query Params: {}
+Shutting down...
+"GET /shutdown HTTP/1.1" 200 -
+
+

--- a/fdw/isolation2/pxf_mock.py
+++ b/fdw/isolation2/pxf_mock.py
@@ -110,8 +110,7 @@ class MockPXFHandler(BaseHTTPRequestHandler):
                 length = int(sline, 16)
 
                 sline = self.rfile.read(length)
-                # chunk = sline.decode('utf-8')
-
+ 
                 if length != len(sline):
                     print("WARNING: invalid message length")
                 ret.append(sline)

--- a/fdw/isolation2/pxf_mock.py
+++ b/fdw/isolation2/pxf_mock.py
@@ -1,0 +1,169 @@
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from http.client import HTTPConnection
+from urllib.parse import urlparse, parse_qs
+
+PXF_PORT=5889
+print_headers = False
+
+class Metadata:
+
+    class MetadataItem:
+        def __init__(self, length, value):
+            self.length = length
+            self.value = value
+
+        def __str__(self):
+            return f"<MetadataItem: {self.value} ({self.length})>"
+
+    def __init__(self, metadata):
+        self.metadata = metadata
+        self.items = []
+        self._parse()
+
+    def _parse(self):
+        # Read metadata item length from binary form
+        i = 0
+        while i < len(self.metadata):
+            length = self.metadata[i:i+4]
+            length = int.from_bytes(length, byteorder='little')
+
+            i = i+4
+            value = self.metadata[i:i+length]
+            self.items.append(Metadata.MetadataItem(length, value))
+            i = i+length
+
+    def contains(self, key):
+        for item in self.items:
+            if item.value == key:
+                return True
+    
+    def sorted(self):
+        return sorted(self.items, key=lambda item: item.value)
+
+class MockPXFHandler(BaseHTTPRequestHandler):
+
+    def __init__(self, request, client_address, server):
+        super().__init__(request, client_address, server)
+
+
+    def log_message(self, format, *args):
+        # Override log message to avoid printing datetime, so result will be reproducible
+        print(format % args)
+
+    def _log_request(self):
+        # Parse URL
+        parsed_path = urlparse(self.path)
+        query_params = parse_qs(parsed_path.query)
+
+        print("\n--- Incoming Request ---")
+        print(f"Method: {self.command}")
+        print(f"Path: {parsed_path.path}")
+        print(f"Query Params: {query_params}")
+
+        # Log headers
+        if print_headers:
+            print("\nHeaders:")
+            for key, value in self.headers.items():
+                print(f"{key}: {value}")
+
+
+    def _log_body(self):
+        content_length = self.headers.get('Content-Length')
+        if content_length:
+            length = int(content_length)
+            body = self.rfile.read(length).decode('utf-8', errors='ignore')
+            print("\nContent-Length: " + str(length) + "\nBody ():")
+            print(body)
+
+    def _send_ok(self, message):
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain")
+        self.end_headers()
+        self.wfile.write(message)
+
+    def do_GET(self):
+        self._log_request()
+        parsed_path = urlparse(self.path)
+        # Shutdown endpoint
+        if parsed_path.path == "/shutdown":
+            print("Shutting down...")
+            self._send_ok(b"Shutting down...")
+
+            # shutdown must be called from another thread
+            threading.Thread(target=self.server.shutdown, daemon=True).start()
+            return
+
+        self._send_ok(b"t0,1")
+
+    def read_chunked(self):
+        ret = []
+        if self.headers.get("Expect", "") == "100-continue":
+            for sline in self.rfile:
+                if  sline == b'0\r\n':
+                    break
+
+                if sline.strip() == b'':
+                    continue
+
+                length = int(sline, 16)
+
+                sline = self.rfile.read(length)
+                # chunk = sline.decode('utf-8')
+
+                if length != len(sline):
+                    print("WARNING: invalid message length")
+                ret.append(sline)
+        return b''.join(ret)
+
+
+    def do_POST(self):
+        parsed_path = urlparse(self.path)
+
+        if parsed_path.path == "/pxf/v1/write":
+            self.read_chunked()
+            # Send some test metadata            
+            metadata = "Some test metadata for " + self.headers.get("X-GP-SEGMENT-ID", "<invalid segment>")
+            self._send_ok(metadata.encode('utf-8'))
+            return
+
+        if parsed_path.path == "/pxf/v1/commit":
+            self._log_request()
+            self._log_body()
+            raw_metadata = self.read_chunked()
+            metadata = Metadata(raw_metadata)
+            for item in metadata.sorted():
+                print(item)
+
+        # Send response
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain")
+        self.end_headers()
+        self.wfile.write(b"OK")
+
+    def do_PUT(self):
+        self.do_POST()
+
+def stop():
+    """
+    Issue http request to stop the server
+
+    """
+
+
+def run(server_class=HTTPServer, handler_class=MockPXFHandler, port=PXF_PORT):
+    server_address = ('', port)
+    httpd = server_class(server_address, handler_class)
+
+    print(f"Starting mock PXF server on port {port}...")
+
+    if len(sys.argv) == 2 and sys.argv[1] == '--stop':
+        stop()
+    else:
+        httpd.serve_forever()
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    run()

--- a/fdw/isolation2/sql/pxf_fdw_metadata.sql
+++ b/fdw/isolation2/sql/pxf_fdw_metadata.sql
@@ -1,0 +1,45 @@
+CREATE EXTENSION IF NOT EXISTS pxf_fdw;
+
+2:!& python3 pxf_mock.py > /tmp/pxf_mock.log 2>&1;
+
+select pg_sleep(1);
+
+CREATE FOREIGN DATA WRAPPER pxf_ext_v1
+    HANDLER pxf_fdw_handler
+    VALIDATOR pxf_fdw_validator
+    OPTIONS (protocol 'system', mpp_execute 'all segments',
+        pxf_protocol 'http', pxf_port '5889', ext_protocol_version 'v1'
+    );
+
+CREATE SERVER pxf_ext_v1_server
+    FOREIGN DATA WRAPPER pxf_ext_v1;
+
+CREATE USER MAPPING FOR CURRENT_USER SERVER pxf_ext_v1_server;
+
+CREATE FOREIGN TABLE test_t(
+    t0 text,
+    a1 integer
+) SERVER pxf_ext_v1_server
+OPTIONS (resource 'fdw_file', format 'csv', delimiter ',');
+
+-- ANALYZE is not supported by pxf_fdw
+set gp_autostats_mode = none;
+set client_min_messages = info;
+
+INSERT INTO test_t VALUES('hello world', 1);
+
+SELECT * FROM test_t ORDER BY t0;
+
+INSERT INTO test_t VALUES('hello world', 1);
+
+SELECT * FROM test_t ORDER BY t0;
+
+1:!& curl http://localhost:5889/shutdown;
+
+2<:
+
+-- sleep to allow the shell properly close the files
+1: select pg_sleep(1);
+
+1:! cat /tmp/pxf_mock.log;
+

--- a/fdw/libchurl.c
+++ b/fdw/libchurl.c
@@ -582,8 +582,6 @@ churl_read_check_connectivity(CHURL_HANDLE handle)
 {
 	churl_context *context = (churl_context *) handle;
 
-	Assert(!context->upload);
-
 	fill_internal_buffer(context, 1);
 }
 
@@ -596,8 +594,6 @@ churl_read(CHURL_HANDLE handle, char *buf, size_t max_size)
 	int			n = 0;
 	churl_context *context = (churl_context *) handle;
 	churl_buffer *context_buffer = context->download_buffer;
-
-	Assert(!context->upload);
 
 	fill_internal_buffer(context, max_size);
 

--- a/fdw/pxf_bridge.c
+++ b/fdw/pxf_bridge.c
@@ -362,7 +362,7 @@ PxfBridgeWrite(PxfFdwModifyState *pxfmstate, char *databuf, int datalen)
 int
 PxfBridgeReceiveMetadata(PxfFdwModifyState *pxfmstate, StringInfo out_buf)
 {
-	char chunk [1024];
+	char chunk[1024];
 
 	if (out_buf == NULL)
 	{
@@ -392,7 +392,6 @@ PxfBridgeReceiveMetadata(PxfFdwModifyState *pxfmstate, StringInfo out_buf)
 
 	return out_buf->len;
 }
-
 
 /*
  * Format the URI for cancel by adding PXF service endpoint details
@@ -547,5 +546,5 @@ PxfBridgeCommitStart(PxfFdwModifyState *pxfmstate)
 		free_churl_ssl_options(ssl_options);
 	}
 
-	elog(DEBUG2, "pxf_fdw: PxfBridgeCommitStart ends on segment: %d", PXF_SEGMENT_ID);
+	elog(DEBUG5, "pxf_fdw: PxfBridgeCommitStart done on segment: %d", PXF_SEGMENT_ID);
 }

--- a/fdw/pxf_bridge.c
+++ b/fdw/pxf_bridge.c
@@ -481,7 +481,7 @@ BuildUriForCommit(PxfFdwModifyState *pxfmstate)
  */
 static size_t
 #if PG_VERSION_NUM >= 90600
-FillBuffer(CHURL_HANDLE handle, char *start, int minlen, int maxlen)
+FillBuffer(CHURL_HANDLE churl_handle, char *start, int minlen, int maxlen)
 #else
 FillBuffer(CHURL_HANDLE churl_handle, char *start, size_t size)
 #endif

--- a/fdw/pxf_bridge.c
+++ b/fdw/pxf_bridge.c
@@ -44,10 +44,11 @@ static void PxfBridgeCancelCleanup(PxfFdwCancelState *pxfcstate);
 static void BuildUriForCancel(PxfFdwCancelState *pxfcstate);
 static void BuildUriForRead(PxfFdwScanState *pxfsstate);
 static void BuildUriForWrite(PxfFdwModifyState *pxfmstate);
+static void BuildUriForCommit(PxfFdwModifyState *pxfmstate);
 #if PG_VERSION_NUM >= 90600
-static size_t FillBuffer(PxfFdwScanState *pxfsstate, char *start, int minlen, int maxlen);
+static size_t FillBuffer(CHURL_HANDLE churl_handle, char *start, int minlen, int maxlen);
 #else
-static size_t FillBuffer(PxfFdwScanState *pxfsstate, char *start, size_t size);
+static size_t FillBuffer(CHURL_HANDLE churl_handle, char *start, size_t size);
 #endif
 
 static churl_ssl_options *churl_make_ssl_options(PxfOptions *options)
@@ -323,9 +324,9 @@ PxfBridgeRead(void *outbuf, int datasize, void *extra)
 	PxfFdwScanState *pxfsstate = (PxfFdwScanState *) extra;
 
 #if PG_VERSION_NUM >= 90600
-	n = FillBuffer(pxfsstate, outbuf, minlen, maxlen);
+	n = FillBuffer(pxfsstate->churl_handle, outbuf, minlen, maxlen);
 #else
-	n = FillBuffer(pxfsstate, outbuf, datasize);
+	n = FillBuffer(pxfsstate->churl_handle, outbuf, datasize);
 #endif
 
 	if (n == 0)
@@ -356,6 +357,42 @@ PxfBridgeWrite(PxfFdwModifyState *pxfmstate, char *databuf, int datalen)
 
 	return (int) n;
 }
+
+/* Receive metadata */
+int
+PxfBridgeReceiveMetadata(PxfFdwModifyState *pxfmstate, StringInfo out_buf)
+{
+	char chunk [1024];
+
+	if (out_buf == NULL)
+	{
+		return 0;
+	}
+
+	while (true)
+	{
+#if PG_VERSION_NUM >= 90600
+		size_t		n = FillBuffer(pxfmstate->churl_handle, chunk, 4, sizeof(chunk));
+#else
+		size_t		n = FillBuffer(pxfmstate->churl_handle, chunk, sizeof(chunk));
+#endif
+		if (n == 0)
+		{
+			/* check if the connection terminated with an error */
+			churl_read_check_connectivity(pxfmstate->churl_handle);
+			break;
+		}
+		else
+		{
+			appendBinaryStringInfo(out_buf, chunk, n);
+		}
+	}
+	elog(DEBUG2, "pxf PxfBridgeRead: segment %d read %d metadata bytes from %s",
+		 PXF_SEGMENT_ID, out_buf->len, pxfmstate->options->resource);
+
+	return out_buf->len;
+}
+
 
 /*
  * Format the URI for cancel by adding PXF service endpoint details
@@ -400,17 +437,44 @@ BuildUriForWrite(PxfFdwModifyState *pxfmstate)
 {
 	PxfOptions *options = pxfmstate->options;
 	const char *protocol = IsProtocolHttps(options->pxf_protocol) ? "https" : "http";
+	bool use_extprotocol = IsExtProtocol(options);
 
 	resetStringInfo(&pxfmstate->uri);
-	appendStringInfo(&pxfmstate->uri, "%s://%s:%d/%s/write", 
-		protocol, options->pxf_host, options->pxf_port, PXF_SERVICE_PREFIX);
+	appendStringInfo(&pxfmstate->uri, "%s://%s:%d/%s/%s%swrite",
+		protocol, options->pxf_host, options->pxf_port,
+		PXF_SERVICE_PREFIX,
+		use_extprotocol ? options->ext_protocol_version : "",
+		use_extprotocol ? "/" : ""
+		);
 
 	if ((LOG >= log_min_messages) || (LOG >= client_min_messages))
 	{
 		appendStringInfo(&pxfmstate->uri, "?trace=true");
 	}
 
-	elog(DEBUG2, "pxf_fdw: uri %s with file name for write: %s", pxfmstate->uri.data, options->resource);
+	elog(DEBUG2, "pxf_fdw: uri %s with file name for write: %s %s",
+		pxfmstate->uri.data, options->resource,
+		use_extprotocol ? "using extprotocol " PXF_EXTPROTOCOL_VERSION : ""
+	);
+}
+
+
+static void
+BuildUriForCommit(PxfFdwModifyState *pxfmstate)
+{
+	PxfOptions *options = pxfmstate->options;
+	const char *protocol = IsProtocolHttps(options->pxf_protocol) ? "https" : "http";
+
+	resetStringInfo(&pxfmstate->uri);
+	appendStringInfo(&pxfmstate->uri, "%s://%s:%d/%s/%s/commit",
+		protocol, options->pxf_host, options->pxf_port, PXF_SERVICE_PREFIX, PXF_EXTPROTOCOL_VERSION_V1);
+
+	if ((LOG >= log_min_messages) || (LOG >= client_min_messages))
+	{
+		appendStringInfo(&pxfmstate->uri, "?trace=true");
+	}
+
+	elog(DEBUG2, "pxf_fdw: uri %s for commit", pxfmstate->uri.data);
 }
 
 /*
@@ -418,9 +482,9 @@ BuildUriForWrite(PxfFdwModifyState *pxfmstate)
  */
 static size_t
 #if PG_VERSION_NUM >= 90600
-FillBuffer(PxfFdwScanState *pxfsstate, char *start, int minlen, int maxlen)
+FillBuffer(CHURL_HANDLE handle, char *start, int minlen, int maxlen)
 #else
-FillBuffer(PxfFdwScanState *pxfsstate, char *start, size_t size)
+FillBuffer(CHURL_HANDLE churl_handle, char *start, size_t size)
 #endif
 {
 	size_t		n = 0;
@@ -431,13 +495,13 @@ FillBuffer(PxfFdwScanState *pxfsstate, char *start, size_t size)
 
 	while (ptr < minend)
 	{
-		n = churl_read(pxfsstate->churl_handle, ptr, maxend - ptr);
+		n = churl_read(churl_handle, ptr, maxend - ptr);
 #else
 	char	   *end = ptr + size;
 
 	while (ptr < end)
 	{
-		n = churl_read(pxfsstate->churl_handle, ptr, end - ptr);
+		n = churl_read(churl_handle, ptr, end - ptr);
 #endif
 		if (n == 0)
 			break;
@@ -446,4 +510,42 @@ FillBuffer(PxfFdwScanState *pxfsstate, char *start, size_t size)
 	}
 
 	return ptr - start;
+}
+
+/*
+ * Upload metadata to the master PXF server
+ */
+void
+PxfBridgeCommitStart(PxfFdwModifyState *pxfmstate)
+{
+	churl_ssl_options *ssl_options = NULL; /* NULL if SSL not used */
+
+	Assert(Gp_role == GP_ROLE_DISPATCH);
+	Assert(pxfmstate != NULL);
+	Assert(pxfmstate->churl_headers == NULL);
+
+	BuildUriForCommit(pxfmstate);
+	pxfmstate->churl_headers = churl_headers_init();
+
+	BuildHttpHeaders(pxfmstate->churl_headers,
+					 pxfmstate->options,
+					 NULL, // Relation is not available at this point
+					 NULL,
+					 NULL,
+					 NULL);
+
+	if (IsProtocolHttps(pxfmstate->options->pxf_protocol))
+	{
+		ssl_options = churl_make_ssl_options(pxfmstate->options);
+	}
+
+	pxfmstate->churl_handle = churl_init_upload_ssl(pxfmstate->uri.data,
+		pxfmstate->churl_headers, ssl_options);
+
+	if (ssl_options != NULL)
+	{
+		free_churl_ssl_options(ssl_options);
+	}
+
+	elog(DEBUG2, "pxf_fdw: PxfBridgeCommitStart ends on segment: %d", PXF_SEGMENT_ID);
 }

--- a/fdw/pxf_bridge.c
+++ b/fdw/pxf_bridge.c
@@ -364,10 +364,7 @@ PxfBridgeReceiveMetadata(PxfFdwModifyState *pxfmstate, StringInfo out_buf)
 {
 	char chunk[1024];
 
-	if (out_buf == NULL)
-	{
-		return 0;
-	}
+	Assert(out_buf != NULL);
 
 	while (true)
 	{

--- a/fdw/pxf_bridge.h
+++ b/fdw/pxf_bridge.h
@@ -85,6 +85,9 @@ void		PxfBridgeImportStart(PxfFdwScanState *pxfsstate);
 /* Sets up data before starting export */
 void		PxfBridgeExportStart(PxfFdwModifyState *pxfmstate);
 
+/* Sets up data before starting metadata commit */
+void		PxfBridgeCommitStart(PxfFdwModifyState *pxfmstate);
+
 /* Reads data from the PXF server into the given buffer of a given size */
 #if PG_VERSION_NUM >= 90600
 int			PxfBridgeRead(void *outbuf, int minlen, int maxlen, void *extra);
@@ -94,5 +97,8 @@ int			PxfBridgeRead(void *outbuf, int datasize, void *extra);
 
 /* Writes data from the given buffer of a given size to the PXF server */
 int			PxfBridgeWrite(PxfFdwModifyState *context, char *databuf, int datalen);
+
+/* Reads metadata from the PXF server v1 and sends it to the coordinator */
+int PxfBridgeReceiveMetadata(PxfFdwModifyState *pxfmstate, StringInfo buf);
 
 #endif							/* _PXFBRIDGE_H */

--- a/fdw/pxf_fdw.c
+++ b/fdw/pxf_fdw.c
@@ -16,13 +16,16 @@
 #if PG_VERSION_NUM >= 90600
 #include "access/table.h"
 #endif
+#include "access/xact.h"
 #include "cdb/cdbsreh.h"
 #include "cdb/cdbvars.h"
+#include "cdb/cdbconn.h"
 #include "commands/copy.h"
 #include "commands/defrem.h"
 #include "commands/explain.h"
 #include "foreign/fdwapi.h"
 #include "foreign/foreign.h"
+#include "libpq/libpq.h"
 #include "nodes/pg_list.h"
 #if PG_VERSION_NUM >= 90600
 #include "optimizer/optimizer.h"
@@ -104,7 +107,8 @@ static void InitCopyStateForModify(PxfFdwModifyState *pxfmstate);
 static CopyState BeginCopyTo(Relation forrel, List *options);
 static void PxfBeginScanErrorCallback(void *arg);
 static void PxfCopyFromErrorCallback(void *arg);
-
+static void CollectMetadata(StringInfo msgbuf);
+static void PxfCollectMetadata(PxfFdwModifyState *pxfmstate);
 /*
  * Foreign-data wrapper handler functions:
  * returns a struct with pointers to the
@@ -648,6 +652,7 @@ InitForeignModify(Relation relation)
 	Oid			foreigntableid;
 	PxfOptions *options = NULL;
 	PxfFdwModifyState *pxfmstate = NULL;
+	MemoryContext oldcontext = NULL;
 #if PG_VERSION_NUM < 90600
 	TupleDesc	tupDesc;
 #endif
@@ -658,16 +663,26 @@ InitForeignModify(Relation relation)
 
 	foreigntableid = RelationGetRelid(relation);
 	rel = GetForeignTable(foreigntableid);
+	options = PxfGetOptions(foreigntableid);
 
-	if (Gp_role == GP_ROLE_DISPATCH && rel->exec_location == FTEXECLOCATION_ALL_SEGMENTS)
+	if (Gp_role == GP_ROLE_DISPATCH && IsExtCommitMetadataSupported(options))
+	{
+		elog(DEBUG5, "pxf_fdw: Use extended commit protocol");
+		oldcontext = MemoryContextSwitchTo(CurTransactionContext);
+
+		pfree(options);
+		options = PxfGetOptions(foreigntableid);
+	}
+
+	if (Gp_role == GP_ROLE_DISPATCH && rel->exec_location == FTEXECLOCATION_ALL_SEGMENTS && oldcontext == NULL)
 		/* master does not process any data when exec_location is all segments */
 		return NULL;
 
 #if PG_VERSION_NUM < 90600
 	tupDesc = RelationGetDescr(relation);
 #endif
-	options = PxfGetOptions(foreigntableid);
-	pxfmstate = palloc(sizeof(PxfFdwModifyState));
+
+	pxfmstate = palloc0(sizeof(PxfFdwModifyState));
 
 	initStringInfo(&pxfmstate->uri);
 	pxfmstate->relation = relation;
@@ -677,7 +692,18 @@ InitForeignModify(Relation relation)
 	pxfmstate->nulls = (bool *) palloc(tupDesc->natts * sizeof(bool));
 #endif
 
-	InitCopyStateForModify(pxfmstate);
+	if (Gp_role == GP_ROLE_DISPATCH)
+	{
+		PQCreateMetadataQueue(PXF_METADATA_QUEUE_ID);
+	}
+
+	if (!(Gp_role == GP_ROLE_DISPATCH && rel->exec_location == FTEXECLOCATION_ALL_SEGMENTS))
+	{
+		InitCopyStateForModify(pxfmstate);
+	}
+
+	if (oldcontext != NULL)
+		MemoryContextSwitchTo(oldcontext);
 
 	elog(DEBUG5, "pxf_fdw: pxfBeginForeignModify ends on segment: %d", PXF_SEGMENT_ID);
 	return pxfmstate;
@@ -782,10 +808,34 @@ FinishForeignModify(PxfFdwModifyState *pxfmstate)
 	if (pxfmstate == NULL)
 		return;
 
-	EndCopyFrom(pxfmstate->cstate);
-	pxfmstate->cstate = NULL;
-	PxfBridgeCleanup(pxfmstate);
+	if (IsExtCommitMetadataSupported(pxfmstate->options))
+	{
+		if (Gp_role == GP_ROLE_DISPATCH)
+		{
+			PxfBridgeCommitStart(pxfmstate);
+			PxfCollectMetadata(pxfmstate);
+			PQDeleteMetadataQueue(PXF_METADATA_QUEUE_ID);
+		}
+		if (Gp_role == GP_ROLE_EXECUTE)
+		{
+			StringInfoData buf;
+			initStringInfo(&buf);
 
+			if (PxfBridgeReceiveMetadata(pxfmstate, &buf) > 0)
+			{
+				pq_metadatasend(buf.data, buf.len, PXF_METADATA_QUEUE_ID);
+			}
+
+			pfree(buf.data);
+		}
+	}
+
+	if (pxfmstate->cstate != NULL)
+	{
+		EndCopyFrom(pxfmstate->cstate);
+		pxfmstate->cstate = NULL;
+	}
+	PxfBridgeCleanup(pxfmstate);
 }
 
 /*
@@ -1105,4 +1155,41 @@ PxfCopyFromErrorCallback(void *arg)
             }
         }
     }
+}
+
+static void
+PxfCollectMetadata(PxfFdwModifyState *pxfmstate)
+{
+	StringInfoData	fe_msgbuf;
+
+	initStringInfo(&fe_msgbuf);
+
+	CollectMetadata(&fe_msgbuf);
+
+	int			bytes_written = PxfBridgeWrite(pxfmstate, fe_msgbuf.data, fe_msgbuf.len);
+
+	if (bytes_written == -1)
+	{
+		ereport(ERROR,
+				(errcode_for_file_access(),
+				 errmsg("could not write to foreign resource: %m")));
+	}
+
+	elog(DEBUG2, "pxf_fdw %d bytes metadata written at commit", bytes_written);
+}
+
+static void
+CollectMetadata(StringInfo msgbuf)
+{
+	ggMetadataChunkIterator it = PQMetadataWalk(PXF_METADATA_QUEUE_ID);
+
+	for (; it; it = PQgetNextMetadata(it))
+	{
+		ggMetadataDescriptor metadata;
+
+		PQgetMetadata(it, &metadata);
+
+		appendBinaryStringInfo(msgbuf, &metadata.metadataLen, sizeof(metadata.metadataLen));
+		appendBinaryStringInfo(msgbuf, metadata.data, metadata.metadataLen);
+	}
 }

--- a/fdw/pxf_fdw.c
+++ b/fdw/pxf_fdw.c
@@ -667,7 +667,7 @@ InitForeignModify(Relation relation)
 
 	if (Gp_role == GP_ROLE_DISPATCH && IsExtCommitMetadataSupported(options))
 	{
-		elog(DEBUG5, "pxf_fdw: Use extended commit protocol");
+		elog(DEBUG2, "pxf_fdw: Use extended commit protocol");
 		oldcontext = MemoryContextSwitchTo(CurTransactionContext);
 
 		pfree(options);
@@ -681,7 +681,6 @@ InitForeignModify(Relation relation)
 #if PG_VERSION_NUM < 90600
 	tupDesc = RelationGetDescr(relation);
 #endif
-
 	pxfmstate = palloc0(sizeof(PxfFdwModifyState));
 
 	initStringInfo(&pxfmstate->uri);
@@ -836,6 +835,7 @@ FinishForeignModify(PxfFdwModifyState *pxfmstate)
 		pxfmstate->cstate = NULL;
 	}
 	PxfBridgeCleanup(pxfmstate);
+
 }
 
 /*
@@ -1176,6 +1176,8 @@ PxfCollectMetadata(PxfFdwModifyState *pxfmstate)
 	}
 
 	elog(DEBUG2, "pxf_fdw %d bytes metadata written at commit", bytes_written);
+
+	pfree(fe_msgbuf.data);
 }
 
 static void

--- a/fdw/pxf_fdw.c
+++ b/fdw/pxf_fdw.c
@@ -17,9 +17,9 @@
 #include "access/table.h"
 #endif
 #include "access/xact.h"
+#include "cdb/cdbconn.h"
 #include "cdb/cdbsreh.h"
 #include "cdb/cdbvars.h"
-#include "cdb/cdbconn.h"
 #include "commands/copy.h"
 #include "commands/defrem.h"
 #include "commands/explain.h"

--- a/fdw/pxf_fdw.c
+++ b/fdw/pxf_fdw.c
@@ -41,6 +41,9 @@
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
 
+#include <dlfcn.h>
+#include <stdio.h>
+
 PG_MODULE_MAGIC;
 
 #define DEFAULT_PXF_FDW_STARTUP_COST   50000
@@ -50,6 +53,41 @@ PG_MODULE_MAGIC;
  */
 #define PXF_ERROR_TOKEN "PXFERRMSG> "
 #define PXF_ERROR_TOKEN_SIZE strlen(PXF_ERROR_TOKEN)
+
+#define LOAD_FN_PTR(base, name) ((PQMetadataInterface_p.name ## _pfn = (name ## _fn)load_optional_function(#name)) != NULL)
+#define CALL_PQ_FN(name, ...) ((PQMetadataInterface_p.name ## _pfn != NULL) ? PQMetadataInterface_p.name ## _pfn(__VA_ARGS__) : 0)
+
+typedef ggMetadataChunkIterator (*PQMetadataWalk_fn)(ggMetadataQueueId queue_id);
+typedef ggMetadataChunkIterator (*PQgetNextMetadata_fn)(ggMetadataChunkIterator it);
+typedef void (*PQgetMetadata_fn)(ggMetadataChunkIterator it, ggMetadataDescriptor *out_desc);
+typedef int	(*PQgetMetadataCount_fn)(ggMetadataQueueId queue_id);
+typedef void (*PQCleanMetadata_fn)(ggMetadataQueueId queue_id);
+
+typedef ggMetadataQueueId (*PQMetadataNextQueueId_fn)(void);
+typedef void (*PQCreateMetadataQueue_fn)(ggMetadataQueueId queue_id);
+typedef void (*PQDeleteMetadataQueue_fn)(ggMetadataQueueId queue_id);
+
+typedef void (*myfunc_t)(int);
+
+static myfunc_t load_optional_function(const char *name);
+static bool init_metadata_interface(void);
+
+typedef struct PQMetadataInterface
+{
+	bool loaded;
+
+	PQMetadataWalk_fn PQMetadataWalk_pfn;
+	PQgetNextMetadata_fn PQgetNextMetadata_pfn;
+	PQgetMetadata_fn PQgetMetadata_pfn;
+	PQgetMetadataCount_fn PQgetMetadataCount_pfn;
+	PQCleanMetadata_fn PQCleanMetadata_pfn;
+
+	PQMetadataNextQueueId_fn PQMetadataNextQueueId_pfn;
+	PQCreateMetadataQueue_fn PQCreateMetadataQueue_pfn;
+	PQDeleteMetadataQueue_fn PQDeleteMetadataQueue_pfn;
+} PQMetadataInterface;
+
+static PQMetadataInterface PQMetadataInterface_p = {false};
 
 extern Datum pxf_fdw_handler(PG_FUNCTION_ARGS);
 
@@ -665,7 +703,7 @@ InitForeignModify(Relation relation)
 	rel = GetForeignTable(foreigntableid);
 	options = PxfGetOptions(foreigntableid);
 
-	if (Gp_role == GP_ROLE_DISPATCH && IsExtCommitMetadataSupported(options))
+	if (Gp_role == GP_ROLE_DISPATCH && IsExtCommitMetadataSupported(options) && init_metadata_interface() != 0)
 	{
 		elog(DEBUG2, "pxf_fdw: Use extended commit protocol");
 		oldcontext = MemoryContextSwitchTo(CurTransactionContext);
@@ -691,9 +729,9 @@ InitForeignModify(Relation relation)
 	pxfmstate->nulls = (bool *) palloc(tupDesc->natts * sizeof(bool));
 #endif
 
-	if (Gp_role == GP_ROLE_DISPATCH)
+	if (Gp_role == GP_ROLE_DISPATCH && PQMetadataInterface_p.loaded)
 	{
-		PQCreateMetadataQueue(PXF_METADATA_QUEUE_ID);
+		CALL_PQ_FN(PQCreateMetadataQueue, PXF_METADATA_QUEUE_ID);
 	}
 
 	if (!(Gp_role == GP_ROLE_DISPATCH && rel->exec_location == FTEXECLOCATION_ALL_SEGMENTS))
@@ -813,7 +851,7 @@ FinishForeignModify(PxfFdwModifyState *pxfmstate)
 		{
 			PxfBridgeCommitStart(pxfmstate);
 			PxfCollectMetadata(pxfmstate);
-			PQDeleteMetadataQueue(PXF_METADATA_QUEUE_ID);
+			PQMetadataInterface_p.PQDeleteMetadataQueue_pfn(PXF_METADATA_QUEUE_ID);
 		}
 		if (Gp_role == GP_ROLE_EXECUTE)
 		{
@@ -1183,15 +1221,63 @@ PxfCollectMetadata(PxfFdwModifyState *pxfmstate)
 static void
 CollectMetadata(StringInfo msgbuf)
 {
-	ggMetadataChunkIterator it = PQMetadataWalk(PXF_METADATA_QUEUE_ID);
+	ggMetadataChunkIterator it = CALL_PQ_FN(PQMetadataWalk, PXF_METADATA_QUEUE_ID);
 
-	for (; it; it = PQgetNextMetadata(it))
+	for (; it; it = CALL_PQ_FN(PQgetNextMetadata, it))
 	{
 		ggMetadataDescriptor metadata;
-
-		PQgetMetadata(it, &metadata);
+		
+		CALL_PQ_FN(PQgetMetadata, it, &metadata);
 
 		appendBinaryStringInfo(msgbuf, &metadata.metadataLen, sizeof(metadata.metadataLen));
 		appendBinaryStringInfo(msgbuf, metadata.data, metadata.metadataLen);
 	}
+}
+
+
+static myfunc_t
+load_optional_function(const char *name)
+{
+    dlerror(); /* clear */
+
+    void *sym = dlsym(RTLD_DEFAULT, name);
+
+    const char *err = dlerror();
+    if (err != NULL)
+	{
+		elog(WARNING, "could not load %s: %s", name, err);
+		return NULL;
+	}
+
+    return (myfunc_t)sym;
+}
+
+static bool
+init_metadata_interface(void)
+{
+	if (PQMetadataInterface_p.loaded)
+		return true;
+
+	bool loaded = true;
+
+	loaded = loaded && LOAD_FN_PTR(PQMetadataInterface_p, PQMetadataWalk);
+	loaded = loaded && LOAD_FN_PTR(PQMetadataInterface_p, PQgetNextMetadata);
+	loaded = loaded && LOAD_FN_PTR(PQMetadataInterface_p, PQgetMetadata);
+	loaded = loaded && LOAD_FN_PTR(PQMetadataInterface_p, PQgetMetadataCount);
+	loaded = loaded && LOAD_FN_PTR(PQMetadataInterface_p, PQCleanMetadata);
+
+	loaded = loaded && LOAD_FN_PTR(PQMetadataInterface_p, PQMetadataNextQueueId);
+	loaded = loaded && LOAD_FN_PTR(PQMetadataInterface_p, PQCreateMetadataQueue);
+	loaded = loaded && LOAD_FN_PTR(PQMetadataInterface_p, PQDeleteMetadataQueue);
+
+	if (!loaded)
+	{
+		elog(WARNING, "could not load PQMetadataInterface");
+	}
+	else
+	{
+		elog(DEBUG2, "loaded PQMetadataInterface");
+	}
+	PQMetadataInterface_p.loaded = loaded;
+	return loaded;
 }

--- a/fdw/pxf_fdw.h
+++ b/fdw/pxf_fdw.h
@@ -22,6 +22,8 @@
 #ifndef PXF_FDW_H
 #define PXF_FDW_H
 
+#define PXF_METADATA_QUEUE_ID 0
+
 /* in pxf_deparse.c */
 extern void deparseTargetList(Relation rel, Bitmapset *attrs_used, List **retrieved_attrs);
 extern void classifyConditions(PlannerInfo *root, RelOptInfo *baserel, List *input_conds, List **remote_conds, List **local_conds);

--- a/fdw/pxf_option.c
+++ b/fdw/pxf_option.c
@@ -45,6 +45,7 @@
 #define FDW_OPTION_REJECT_LIMIT "reject_limit"
 #define FDW_OPTION_REJECT_LIMIT_TYPE "reject_limit_type"
 #define FDW_OPTION_RESOURCE "resource"
+#define FDW_OPTION_EXT_PROTOCOL_VERSION "ext_protocol_version"
 
 #define FDW_COPY_OPTION_FORMAT "format"
 #define FDW_COPY_OPTION_HEADER "header"
@@ -69,6 +70,7 @@ struct PxfFdwOption
 
 static const struct PxfFdwOption valid_options[] = {
 	{FDW_OPTION_PROTOCOL, ForeignDataWrapperRelationId},
+	{FDW_OPTION_EXT_PROTOCOL_VERSION, ForeignDataWrapperRelationId},
 	{FDW_OPTION_RESOURCE, ForeignTableRelationId},
 	{FDW_OPTION_FORMAT, ForeignTableRelationId},
 	{FDW_OPTION_CONFIG, ForeignServerRelationId},
@@ -147,6 +149,7 @@ Datum
 pxf_fdw_validator(PG_FUNCTION_ARGS)
 {
 	char	   *protocol = NULL;
+	char	   *ext_protocol_version = NULL;
 	char	   *resource = NULL;
 	char	   *reject_limit_type = FDW_OPTION_REJECT_LIMIT_ROWS;
 	bool		log_errors_set = false;
@@ -169,6 +172,8 @@ pxf_fdw_validator(PG_FUNCTION_ARGS)
 
 		if (strcmp(def->defname, FDW_OPTION_PROTOCOL) == 0)
 			protocol = defGetString(def);
+		else if(strcmp(def->defname, FDW_OPTION_EXT_PROTOCOL_VERSION) == 0)
+			ext_protocol_version = defGetString(def);
 		else if (strcmp(def->defname, FDW_OPTION_RESOURCE) == 0)
 			resource = defGetString(def);
 		else if (strcmp(def->defname, FDW_OPTION_MPP_EXECUTE) == 0)
@@ -483,6 +488,8 @@ PxfGetOptions(Oid foreigntableid)
 			opt->pxf_ssl_verify_peer = defGetBoolean(def);
 		else if (strcmp(def->defname, FDW_OPTION_PROTOCOL) == 0)
 			opt->protocol = defGetString(def);
+		else if (strcmp(def->defname, FDW_OPTION_EXT_PROTOCOL_VERSION) == 0)
+			opt->ext_protocol_version = defGetString(def);
 		else if (strcmp(def->defname, FDW_OPTION_RESOURCE) == 0)
 			opt->resource = defGetString(def);
 		else if (strcmp(def->defname, FDW_OPTION_REJECT_LIMIT) == 0)
@@ -624,4 +631,11 @@ ValidateOption(char *option, Oid catalog)
 							RelationGetRelationName(rel))));
 		}
 	}
+}
+
+bool
+IsExtCommitMetadataSupported(PxfOptions *options)
+{
+	return  IsExtProtocol(options) &&
+		!strcmp(ExtProtocolVersion(options), PXF_EXTPROTOCOL_VERSION_V1);
 }

--- a/fdw/pxf_option.h
+++ b/fdw/pxf_option.h
@@ -17,6 +17,9 @@
 #define PXF_FDW_DEFAULT_HOST     "localhost"
 #define PXF_FDW_DEFAULT_PORT     5888
 
+#define PXF_EXTPROTOCOL_VERSION    "ext_protocol_version"
+#define PXF_EXTPROTOCOL_VERSION_V1 "v1"
+
 /*
  * Structure to store the PXF options */
 typedef struct PxfOptions
@@ -54,6 +57,7 @@ typedef struct PxfOptions
 	char	   *resource;		/* PXF resource */
 	char	   *format;			/* PXF resource format */
 	char	   *profile;		/* protocol[:format] */
+	char	   *ext_protocol_version;
 
 	List	   *copy_options;	/* merged options for COPY */
 	List	   *options;		/* merged options, excluding COPY, protocol,
@@ -67,5 +71,10 @@ typedef struct PxfOptions
 
 /* Functions prototypes for pxf_option.c file */
 PxfOptions *PxfGetOptions(Oid foreigntableid);
+
+#define IsExtProtocol(options) ((options)->ext_protocol_version != NULL)
+#define ExtProtocolVersion(options) (IsExtProtocol(options) ? (options)->ext_protocol_version : NULL)
+
+bool IsExtCommitMetadataSupported(PxfOptions *options);
 
 #endif							/* _PXF_OPTION_H */


### PR DESCRIPTION
Support optional Greengage metadata commit protocol in PXF

The PXF plugin now works regardless of whether Greengage supports the
extended metadata commit protocol. This change dynamically loads the
metadata commit protocol API functions into the virtual table and
conditionally invokes them based on availability.

ADBDEV-9857