### PR TITLE
ADBDEV-10126: Fix "Fragmenter & Bridge Call Rate" dashboard

### DIFF
--- a/deploy/grafana/gg-pxf-dashboard.json
+++ b/deploy/grafana/gg-pxf-dashboard.json
@@ -1145,32 +1145,7 @@
               },
               "unit": "reqps"
             },
-            "overrides": [
-              {
-                "__systemRef": "hideSeriesFrom",
-                "matcher": {
-                  "id": "byNames",
-                  "options": {
-                    "mode": "exclude",
-                    "names": [
-                      "bridge call success - tkh/dkhomutov-adb-3.ru-central1.internal:5888"
-                    ],
-                    "prefix": "All except:",
-                    "readOnly": true
-                  }
-                },
-                "properties": [
-                  {
-                    "id": "custom.hideFrom",
-                    "value": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": true
-                    }
-                  }
-                ]
-              }
-            ]
+            "overrides": []
           },
           "gridPos": {
             "h": 8,

--- a/server/pxf-service/src/main/java/org/greenplum/pxf/service/security/SecurityConfig.java
+++ b/server/pxf-service/src/main/java/org/greenplum/pxf/service/security/SecurityConfig.java
@@ -31,28 +31,37 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.intercept.RequestAuthorizationContext;
 import org.springframework.security.web.util.matcher.IpAddressMatcher;
 
+import java.util.List;
+
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
 
-    private static final String LOCALHOST_IP_ADDRESS = "127.0.0.1";
+    private static final String LOCALHOST_IPV4_ADDRESS = "127.0.0.1";
+    private static final String LOCALHOST_IPV6_ADDRESS = "::1";
+    private static final List<IpAddressMatcher> ipAddressMatchers = List.of(
+            new IpAddressMatcher(LOCALHOST_IPV4_ADDRESS),
+            new IpAddressMatcher(LOCALHOST_IPV6_ADDRESS)
+    );
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
         http
                 .csrf(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests(auth -> auth.requestMatchers("/pxf/reload").access(hasIpAddress(LOCALHOST_IP_ADDRESS))
-                        .requestMatchers("/**").permitAll())
-                ;
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/pxf/reload").access(hasLocalhostIpAddress())
+                        .requestMatchers("/**").permitAll());
+
         return http.build();
     }
 
-    private static AuthorizationManager<RequestAuthorizationContext> hasIpAddress(String ipAddress) {
-        IpAddressMatcher ipAddressMatcher = new IpAddressMatcher(ipAddress);
+    private static AuthorizationManager<RequestAuthorizationContext> hasLocalhostIpAddress() {
         return (authentication, context) -> {
             HttpServletRequest request = context.getRequest();
-            return new AuthorizationDecision(ipAddressMatcher.matches(request));
+            boolean allowed = ipAddressMatchers.stream()
+                    .anyMatch(matcher -> matcher.matches(request));
+            return new AuthorizationDecision(allowed);
         };
     }
 }


### PR DESCRIPTION
- Fix "Fragmenter & Bridge Call Rate" dashboard
- Fix curl request for "pxf cluster reload" command
The /pxf/reload endpoint is intended to be accessible only from the local host.
On some operating systems, localhost resolves to an IPv4 address, while on others it resolves to an IPv6 address.
This commit fixes the issue by allowing access to the endpoint not only from 127.0.0.1 but also from ::1 (IPv6 loopback address)