### PR TITLE
GG-628 Adjust tests for extended metadata in 7.x

### DIFF
--- a/fdw/expected/pxf_fdw_metadata_2.out
+++ b/fdw/expected/pxf_fdw_metadata_2.out
@@ -1,0 +1,161 @@
+--
+-- start_matchignore
+-- m/^DEBUG?:  Interconnect State:/
+-- m/^DEBUG?:  TeardownUDPIFCInterconnect successful/
+-- m/^DEBUG?:  Message type/
+-- m/^DEBUG?:  Query plan size to/
+-- m/^DEBUG?:  GetSockAddr socket ai_family/
+-- m/^DEBUG?:  CommitTransactionCommand:/
+-- m/^DEBUG?:  CommitTransaction:/
+-- m/^DEBUG?:  rehashing catalog cache id/
+-- m/^DEBUG:  GPORCA produced plan/
+-- m/^LOG: .*Feature not supported: Foreign Data/
+-- m/^LOG: .*Feature not supported: SIRV functions/
+-- m/^LOG: .*Falling back to Postgres-based planner because GPORCA/
+-- end_matchignore
+-- Check if metatata is supported in this version of Greengage (6.31+)
+with version as (
+    select string_to_array(substring(version(), '(?:Database\s)(\d+\.\d+)(?:\.\d+)'), '.') as ver
+)
+select ver[1]::int = 6 and ver[2]::int >= 31 from version;
+ ?column? 
+----------
+ t
+(1 row)
+
+CREATE EXTENSION IF NOT EXISTS pxf_fdw;
+NOTICE:  extension "pxf_fdw" already exists, skipping
+\! python3 pxf_mock.py > /tmp/pxf_mock.log 2>&1 &
+\! curl --retry 10 --retry-delay 1 --retry-connrefused -s -o /dev/null http://localhost:5889/
+CREATE FOREIGN DATA WRAPPER pxf_ext_v1
+    HANDLER pxf_fdw_handler
+    VALIDATOR pxf_fdw_validator
+    OPTIONS (protocol 'system', mpp_execute 'all segments',
+        pxf_protocol 'http', pxf_port '5889', ext_protocol_version 'v1'
+    );
+CREATE SERVER pxf_ext_v1_server
+    FOREIGN DATA WRAPPER pxf_ext_v1;
+CREATE USER MAPPING FOR CURRENT_USER SERVER pxf_ext_v1_server;
+CREATE FOREIGN TABLE test_t(
+    t0 text,
+    a1 integer
+) SERVER pxf_ext_v1_server
+OPTIONS (resource 'fdw_file', format 'csv', delimiter ',');
+-- ANALYZE is not supported by pxf_fdw
+set gp_autostats_mode = none;
+set client_min_messages = DEBUG;
+INSERT INTO test_t VALUES('hello world', 1);
+LOG:  statement: INSERT INTO test_t VALUES('hello world', 1);
+DEBUG:  pxf_fdw: metadata queue created with id: 0
+DEBUG:  pxf_fdw: Executor sent metadata (24 bytes) to queue metadata_queue_id: 0  (seg0 127.0.1.1:6002 pid=224388)
+DEBUG:  pxf_fdw: Executor sent metadata (24 bytes) to queue metadata_queue_id: 0  (seg2 127.0.1.1:6004 pid=224387)
+DEBUG:  pxf_fdw: Executor sent metadata (24 bytes) to queue metadata_queue_id: 0  (seg1 127.0.1.1:6003 pid=224386)
+SELECT * FROM test_t ORDER BY t0;
+LOG:  statement: SELECT * FROM test_t ORDER BY t0;
+ t0 | a1 
+----+----
+ t0 |  1
+ t0 |  1
+ t0 |  1
+(3 rows)
+
+INSERT INTO test_t VALUES('hello world', 1);
+LOG:  statement: INSERT INTO test_t VALUES('hello world', 1);
+DEBUG:  pxf_fdw: metadata queue created with id: 1
+DEBUG:  pxf_fdw: Executor sent metadata (24 bytes) to queue metadata_queue_id: 1  (seg2 127.0.1.1:6004 pid=224387)
+DEBUG:  pxf_fdw: Executor sent metadata (24 bytes) to queue metadata_queue_id: 1  (seg0 127.0.1.1:6002 pid=224388)
+DEBUG:  pxf_fdw: Executor sent metadata (24 bytes) to queue metadata_queue_id: 1  (seg1 127.0.1.1:6003 pid=224386)
+SELECT * FROM test_t ORDER BY t0;
+LOG:  statement: SELECT * FROM test_t ORDER BY t0;
+ t0 | a1 
+----+----
+ t0 |  1
+ t0 |  1
+ t0 |  1
+(3 rows)
+
+\! curl -sS http://localhost:5889/shutdown
+Shutting down...\! wait $(pgrep -f "python3 pxf_mock.py" | head -1)
+-- sleep to allow the shell properly close the files
+select pg_sleep(1);
+LOG:  statement: select pg_sleep(1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+\! cat /tmp/pxf_mock.log
+Starting mock PXF server on port 5889...
+
+--- Incoming Request ---
+Method: GET
+Path: /
+Query Params: {}
+"GET / HTTP/1.1" 200 -
+"POST /pxf/v1/write?trace=true HTTP/1.1" 200 -
+"POST /pxf/v1/write?trace=true HTTP/1.1" 200 -
+"POST /pxf/v1/write?trace=true HTTP/1.1" 200 -
+
+--- Incoming Request ---
+Method: POST
+Path: /pxf/v1/commit
+Query Params: {'trace': ['true']}
+<MetadataItem: b'Some test metadata for 0' (24)>
+<MetadataItem: b'Some test metadata for 1' (24)>
+<MetadataItem: b'Some test metadata for 2' (24)>
+"POST /pxf/v1/commit?trace=true HTTP/1.1" 200 -
+
+--- Incoming Request ---
+Method: GET
+Path: /pxf/read
+Query Params: {'trace': ['true']}
+"GET /pxf/read?trace=true HTTP/1.1" 200 -
+
+--- Incoming Request ---
+Method: GET
+Path: /pxf/read
+Query Params: {'trace': ['true']}
+"GET /pxf/read?trace=true HTTP/1.1" 200 -
+
+--- Incoming Request ---
+Method: GET
+Path: /pxf/read
+Query Params: {'trace': ['true']}
+"GET /pxf/read?trace=true HTTP/1.1" 200 -
+"POST /pxf/v1/write?trace=true HTTP/1.1" 200 -
+"POST /pxf/v1/write?trace=true HTTP/1.1" 200 -
+"POST /pxf/v1/write?trace=true HTTP/1.1" 200 -
+
+--- Incoming Request ---
+Method: POST
+Path: /pxf/v1/commit
+Query Params: {'trace': ['true']}
+<MetadataItem: b'Some test metadata for 0' (24)>
+<MetadataItem: b'Some test metadata for 1' (24)>
+<MetadataItem: b'Some test metadata for 2' (24)>
+"POST /pxf/v1/commit?trace=true HTTP/1.1" 200 -
+
+--- Incoming Request ---
+Method: GET
+Path: /pxf/read
+Query Params: {'trace': ['true']}
+"GET /pxf/read?trace=true HTTP/1.1" 200 -
+
+--- Incoming Request ---
+Method: GET
+Path: /pxf/read
+Query Params: {'trace': ['true']}
+"GET /pxf/read?trace=true HTTP/1.1" 200 -
+
+--- Incoming Request ---
+Method: GET
+Path: /pxf/read
+Query Params: {'trace': ['true']}
+"GET /pxf/read?trace=true HTTP/1.1" 200 -
+
+--- Incoming Request ---
+Method: GET
+Path: /shutdown
+Query Params: {}
+Shutting down...
+"GET /shutdown HTTP/1.1" 200 -

--- a/fdw/expected/pxf_fdw_metadata_2.out
+++ b/fdw/expected/pxf_fdw_metadata_2.out
@@ -1,13 +1,13 @@
 --
 -- start_matchignore
--- m/^DEBUG?:  Interconnect State:/
--- m/^DEBUG?:  TeardownUDPIFCInterconnect successful/
--- m/^DEBUG?:  Message type/
--- m/^DEBUG?:  Query plan size to/
--- m/^DEBUG?:  GetSockAddr socket ai_family/
--- m/^DEBUG?:  CommitTransactionCommand:/
--- m/^DEBUG?:  CommitTransaction:/
--- m/^DEBUG?:  rehashing catalog cache id/
+-- m/^DEBUG1?:  Interconnect State:/
+-- m/^DEBUG1?:  TeardownUDPIFCInterconnect successful/
+-- m/^DEBUG1?:  Message type/
+-- m/^DEBUG1?:  Query plan size to/
+-- m/^DEBUG1?:  GetSockAddr socket ai_family/
+-- m/^DEBUG1?:  CommitTransactionCommand:/
+-- m/^DEBUG1?:  CommitTransaction:/
+-- m/^DEBUG1?:  rehashing catalog cache id/
 -- m/^DEBUG:  GPORCA produced plan/
 -- m/^LOG: .*Feature not supported: Foreign Data/
 -- m/^LOG: .*Feature not supported: SIRV functions/
@@ -20,7 +20,7 @@ with version as (
 select ver[1]::int = 6 and ver[2]::int >= 31 from version;
  ?column? 
 ----------
- t
+ f
 (1 row)
 
 CREATE EXTENSION IF NOT EXISTS pxf_fdw;
@@ -43,13 +43,13 @@ CREATE FOREIGN TABLE test_t(
 OPTIONS (resource 'fdw_file', format 'csv', delimiter ',');
 -- ANALYZE is not supported by pxf_fdw
 set gp_autostats_mode = none;
-set client_min_messages = DEBUG;
+set client_min_messages = debug1;
 INSERT INTO test_t VALUES('hello world', 1);
 LOG:  statement: INSERT INTO test_t VALUES('hello world', 1);
 DEBUG:  pxf_fdw: metadata queue created with id: 0
-DEBUG:  pxf_fdw: Executor sent metadata (24 bytes) to queue metadata_queue_id: 0  (seg0 127.0.1.1:6002 pid=224388)
-DEBUG:  pxf_fdw: Executor sent metadata (24 bytes) to queue metadata_queue_id: 0  (seg2 127.0.1.1:6004 pid=224387)
-DEBUG:  pxf_fdw: Executor sent metadata (24 bytes) to queue metadata_queue_id: 0  (seg1 127.0.1.1:6003 pid=224386)
+DEBUG:  pxf_fdw: Executor sent metadata (24 bytes) to queue metadata_queue_id: 0
+DEBUG:  pxf_fdw: Executor sent metadata (24 bytes) to queue metadata_queue_id: 0
+DEBUG:  pxf_fdw: Executor sent metadata (24 bytes) to queue metadata_queue_id: 0
 SELECT * FROM test_t ORDER BY t0;
 LOG:  statement: SELECT * FROM test_t ORDER BY t0;
  t0 | a1 
@@ -62,9 +62,9 @@ LOG:  statement: SELECT * FROM test_t ORDER BY t0;
 INSERT INTO test_t VALUES('hello world', 1);
 LOG:  statement: INSERT INTO test_t VALUES('hello world', 1);
 DEBUG:  pxf_fdw: metadata queue created with id: 1
-DEBUG:  pxf_fdw: Executor sent metadata (24 bytes) to queue metadata_queue_id: 1  (seg2 127.0.1.1:6004 pid=224387)
-DEBUG:  pxf_fdw: Executor sent metadata (24 bytes) to queue metadata_queue_id: 1  (seg0 127.0.1.1:6002 pid=224388)
-DEBUG:  pxf_fdw: Executor sent metadata (24 bytes) to queue metadata_queue_id: 1  (seg1 127.0.1.1:6003 pid=224386)
+DEBUG:  pxf_fdw: Executor sent metadata (24 bytes) to queue metadata_queue_id: 1
+DEBUG:  pxf_fdw: Executor sent metadata (24 bytes) to queue metadata_queue_id: 1
+DEBUG:  pxf_fdw: Executor sent metadata (24 bytes) to queue metadata_queue_id: 1
 SELECT * FROM test_t ORDER BY t0;
 LOG:  statement: SELECT * FROM test_t ORDER BY t0;
  t0 | a1 

--- a/fdw/pxf_fdw.c
+++ b/fdw/pxf_fdw.c
@@ -1296,7 +1296,7 @@ CollectMetadata(PxfFdwModifyState *pxfmstate, StringInfo msgbuf)
 		
 		CALL_PQ_FN(PQgetMetadata, it, &metadata);
 
-		appendBinaryStringInfo(msgbuf, &metadata.metadataLen, sizeof(metadata.metadataLen));
+		appendBinaryStringInfo(msgbuf, (const char *)&metadata.metadataLen, sizeof(metadata.metadataLen));
 		appendBinaryStringInfo(msgbuf, metadata.data, metadata.metadataLen);
 	}
 	elog(DEBUG2, "pxf_fdw: Executor collected metadata from queue metadata_queue_id: %d", pxfmstate->metadata_queue_id);


### PR DESCRIPTION
Commit <TODO> added extended metadata support to 7.x It required adjusting of 
regression tests:

- Add expected output for 7.x with metadata support
- Explicit type cast

Now tests should work with GG 6.x with extended metadata support, and with 7.x 
with and without extended metadata support.
